### PR TITLE
Update absparse.fsy

### DIFF
--- a/src/absparse.fsy
+++ b/src/absparse.fsy
@@ -83,6 +83,7 @@ let normalize_var (v : string) =
 %left   PLUS MINUS
 %left   STAR DIV REM
 %left   UMINUS
+%right  NOT
 
 
 %%


### PR DESCRIPTION
Given two equivalent formulas (1==1) || ! (1==1) and ! (1==1) ||  (1==1) for any T2 file, the verification result should be satisfied. But the second formula ! (1==1) ||  (1==1) is unsatisfied which makes me confused. So I read the file absparse.fsy and find the precedence rule of !(not) is not defined. As a result, ! (1==1) ||  (1==1) is equivalent to ! ((1==1) ||  (1==1)) and the verification is failed. %right NOT is added into absparse.fsy, then the bug is fixed.